### PR TITLE
This moves the Launch Dashboard button to Installed Charts table

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "start": "cross-env NODE_ENV=development webpack serve --hot --host 0.0.0.0 --config=./webpack.dev.config.js --mode development",
     "build": "cross-env NODE_ENV=production webpack --config webpack.build.config.js --mode production",
     "package": "npm run build",
-    "postpackage": "electron-packager ./ --out=./builds",
     "package-mac": "electron-packager . Ahoy --overwrite --platform=darwin --arch=x64 --icon=src/assets/icons/mac/ahoyIcon.icns --prune=true --out=./builds",
     "package-win": "electron-packager . Ahoy --overwrite --asar=true --platform=win32 --arch=ia32 --icon=src/assets/icons/win/ahoyIcon.ico --prune=true --out=./builds --version-string.CompanyName=CE --version-string.FileDescription=CE --version-string.ProductName=\"Ahoy\"",
     "package-linux": "electron-packager . Ahoy --overwrite --asar=true --platform=linux --arch=x64 --icon=src/assets/icons/png/ahoyIcon.png --prune=true --out=./builds",

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -62,3 +62,7 @@ tr.history td{
   border-left: 10px solid #cfcfcf;
   background-color:rgb(249, 250, 251);
 }
+
+#launchDashBoard {
+  float: right;
+}

--- a/src/components/InstalledChartList.jsx
+++ b/src/components/InstalledChartList.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Table } from 'semantic-ui-react';
+import { Table, Button, Icon } from 'semantic-ui-react';
 import InstalledChart from './InstalledChart';
 
 /** Installed Chart List Component */
 const InstalledChartList = (props) => {
   const listData = [];
   const {
-    deployedCharts, getDeployedCharts, toggleHistory, doHelmChartRollBack,
+    deployedCharts, getDeployedCharts, toggleHistory, doHelmChartRollBack, launchMiniKubeDashBoard,
   } = props;
   // Build the installed chart component array
   for (let i = 0; i < deployedCharts.length; i++) {
@@ -27,7 +27,19 @@ const InstalledChartList = (props) => {
     <Table id="installed-charts">
       <Table.Header>
         <Table.Row>
-          <Table.HeaderCell colSpan="2">Installed Charts</Table.HeaderCell>
+          <Table.HeaderCell colSpan="2">
+            Installed Charts
+            <Button
+              compact
+              size="tiny"
+              id="launchDashBoard"
+              onClick={() => launchMiniKubeDashBoard()}
+            >
+              <Icon name="dashboard" />
+              {' '}
+              Launch Dashboard
+            </Button>
+          </Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>{listData}</Table.Body>

--- a/src/containers/InstalledChartContainer.jsx
+++ b/src/containers/InstalledChartContainer.jsx
@@ -1,21 +1,37 @@
-import React from 'react';
+import React, { Component } from 'react';
 import InstalledChartList from '../components/InstalledChartList';
+import launchDashBoard from '../helpers/launchMiniKubeDashBoard';
 
-const InstalledChartContainer = (props) => {
-  const {
-    deployedCharts, getDeployedCharts, toggleHistory, doHelmChartRollBack, currentChartHistory,
-  } = props;
-  return (
-    <div className="outer-container">
-      <InstalledChartList
-        deployedCharts={deployedCharts}
-        getDeployedCharts={getDeployedCharts}
-        toggleHistory={toggleHistory}
-        doHelmChartRollBack={doHelmChartRollBack}
-        currentChartHistory={currentChartHistory}
-      />
-    </div>
-  );
-};
+class InstalledChartContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.launchMiniKubeDashBoard = this.launchMiniKubeDashBoard.bind(this);
+    this.launchDashBoard = launchDashBoard.bind(this);
+  }
+
+  // launches minikube dashboard in a browser window
+  launchMiniKubeDashBoard() {
+    this.launchDashBoard().then((x) => console.log('Dashboard Launched:', x));
+  }
+
+  render() {
+    const {
+      deployedCharts, getDeployedCharts, toggleHistory, doHelmChartRollBack, currentChartHistory,
+    } = this.props;
+
+    return (
+      <div className="outer-container">
+        <InstalledChartList
+          deployedCharts={deployedCharts}
+          getDeployedCharts={getDeployedCharts}
+          toggleHistory={toggleHistory}
+          doHelmChartRollBack={doHelmChartRollBack}
+          currentChartHistory={currentChartHistory}
+          launchMiniKubeDashBoard={this.launchMiniKubeDashBoard}
+        />
+      </div>
+    );
+  }
+}
 
 export default InstalledChartContainer;

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
-import { Button } from 'semantic-ui-react';
 import LocalChartContainer from './LocalChartContainer';
 import InstalledChartContainer from './InstalledChartContainer';
 import getDeployedHelmCharts from '../helpers/getDeployedHelmCharts';
 import getHelmHistory from '../helpers/getHelmHistory';
 import doHelmRollBack from '../helpers/doHelmRollBack';
-import launchDashBoard from '../helpers/launchMiniKubeDashBoard';
 
 const path = require('path');
 const { getLocalCharts } = require('../helpers/FileSystemHelper');
@@ -34,7 +32,6 @@ class MainContainer extends Component {
     this.getHistory = this.getHistory.bind(this);
     this.toggleHistory = this.toggleHistory.bind(this);
     this.doHelmChartRollBack = this.doHelmChartRollBack.bind(this);
-    this.launchMiniKubeDashBoard = this.launchMiniKubeDashBoard.bind(this);
   }
 
   // Get list of running Helm Charts upon app start. Helm charts are independent of the app status
@@ -115,24 +112,12 @@ class MainContainer extends Component {
       .then('Successfully rolled back!');
   }
 
-  // launches minikube dashboard in a browser window
-  launchMiniKubeDashBoard() {
-    console.log('Launching Minikube Dashboard...');
-    launchDashBoard().then((x) => console.log('Dashboard Launched:', x));
-  }
-
   render() {
     const {
-      userChartDir, localCharts, deployedCharts, showAlert,
+      userChartDir, localCharts, deployedCharts,
     } = this.state;
     return (
       <>
-        <Button 
-          id="launchDashBoard"
-          onClick={() => this.launchMiniKubeDashBoard()}
-        >
-          Launch Dashboard
-        </Button>
         <LocalChartContainer
           userChartDir={userChartDir}
           localCharts={localCharts}


### PR DESCRIPTION
- moved launchMiniKubeDashBoard() to InstalledChartContainer
- InstalledChartContainer is now a class component
- minikube dashboard button is not in the installed charts table header

 - Co-authored-by: Jin Oh <65692508+ohjintech@users.noreply.github.com>
 - Co-authored-by: Joe Bigelow <65265765+lilbigs2001@users.noreply.github.com>
 - Co-authored-by: Yoko Kawamoto <7126966+libero-yoko@users.noreply.github.com> 